### PR TITLE
Add basic sprockets support

### DIFF
--- a/lib/hotwire/spark/engine.rb
+++ b/lib/hotwire/spark/engine.rb
@@ -18,6 +18,10 @@ module Hotwire::Spark
       end
     end
 
+    initializer "hotwire_spark.assets" do |application|
+      application.config.assets.precompile << "hotwire_spark.js"
+    end
+
     initializer "hotwire_spark.install" do |application|
       Hotwire::Spark.install_into application if Hotwire::Spark.enabled?
     end


### PR DESCRIPTION
Add hotwire_spark.js to the precompiled assets. This adds Sprockets support for Rails 8 applications. Fixes #36.