### PR TITLE
Use view_helpers of the controller instance instead of standalone module

### DIFF
--- a/lib/hotwire/spark/middleware.rb
+++ b/lib/hotwire/spark/middleware.rb
@@ -7,6 +7,7 @@ class Hotwire::Spark::Middleware
     status, headers, response = @app.call(env)
 
     if html_response?(headers)
+      @request = ActionDispatch::Request.new(env)
       html = html_from(response)
       html = inject_javascript(html)
       html = inject_options(html)
@@ -38,7 +39,7 @@ class Hotwire::Spark::Middleware
     end
 
     def view_helpers
-      ActionController::Base.helpers
+      @request.controller_instance.helpers
     end
 
     def inject_options(html)

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -25,5 +25,7 @@ module Dummy
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+
+    config.asset_host = ->(asset, request) { "#{request.host}:#{request.port}" }
   end
 end


### PR DESCRIPTION
I could reproduce this issue by configuring the dummy app as shown in this PR and rendering the root path of the dummy app.

If you're using an `asset_host` lambda to generate a host based on the request, some view helpers in the middleware fail with an `ArgumentError`. Before this PR, the middleware used `ActionView::Base.helpers`, which doesn't know about the current request. This will result in an ArgumentError with an backtrace similar to:

```
[config/application.rb:29:in `block in <class:Application>'](http://localhost:3000/#)
[actionview (8.0.0) lib/action_view/helpers/asset_url_helper.rb:287:in `compute_asset_host'](http://localhost:3000/#)
[actionview (8.0.0) lib/action_view/helpers/asset_url_helper.rb:213:in `asset_path'](http://localhost:3000/#)
[/hotwire-spark/lib/hotwire/spark/middleware.rb:37:in `script_tag'](http://localhost:3000/#)
[/hotwire-spark/lib/hotwire/spark/middleware.rb:33:in `inject_javascript'](http://localhost:3000/#)
[/hotwire-spark/lib/hotwire/spark/middleware.rb:12:in `call'](http://localhost:3000/#)
[rack (3.1.8) lib/rack/tempfile_reaper.rb:20:in `call'](http://localhost:3000/#)
...
```

Basically if `asset_host` is a [lambda with 2 or more args](https://github.com/rails/rails/blob/main/actionview/lib/action_view/helpers/asset_url_helper.rb#L286), `compute_asset_host` wants to be called in a request context.

Since we're in a middleware, we have access to the current request, which should allow us to access the asset helpers in a request context. I'm using `@request.controller_instance.helpers` to access the view helpers, which has the advantage of being in context of the request/controller. This fixes #43.

Maybe this bug doesn't really warrant the dummy app to be reconfigured though 🤔