### PR TITLE
Add view components path by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ config.hotwire.spark.html_paths += %w[ lib ]
 
 | Name                  | Description                                                                                                                  |
 |-----------------------|------------------------------------------------------------------------------------------------------------------------------|
-| `html_paths`          | Paths where file changes trigger a content refresh. By default: `app/controllers`, `app/helpers`, `app/models`, `app/views`. |
+| `html_paths`          | Paths where file changes trigger a content refresh. By default: `app/components`, `app/controllers`, `app/helpers`, `app/models`, `app/views`. |
 | `html_extensions`     | The extensions to monitor for HTML content changes. By default: `rb`, `erb`.                                                 |                                                                                                                                                                                                                                                   |
 | `css_paths`           | Paths where file changes trigger a CSS refresh. By default: `app/assets/stylesheets` or `app/assets/builds` if exists.       |
 | `css_extensions`      | The extensions to monitor for CSS changes. By default: `css`.                                                                |                                                                                                                                                                                                                                                   |

--- a/lib/hotwire/spark/default_options.rb
+++ b/lib/hotwire/spark/default_options.rb
@@ -15,7 +15,7 @@ class Hotwire::Spark::DefaultOptions
         enabled: Rails.env.development?,
         css_paths: File.directory?("app/assets/builds") ? %w[ app/assets/builds ] : %w[ app/assets/stylesheets ],
         css_extensions: %w[ css ],
-        html_paths: %w[ app/controllers app/helpers app/models app/views ],
+        html_paths: %w[ app/components app/controllers app/helpers app/models app/views ],
         html_extensions: %w[ rb erb ],
         stimulus_paths: %w[ app/javascript/controllers ],
         stimulus_extensions: %w[ js ],


### PR DESCRIPTION
I know view components aren't the Rails default but what do you think about adding it by default to be watched?

It's easy enough to add to a project with `config.hotwire.spark.html_paths += %w[ app/components ]` so if this gets declined it's not the end of the world.

If there's no performance issues with watching it by default I figured it wouldn't hurt to add it so it works out of the box for more folks who have slightly deviated from the Rails defaults.

Btw, I listed this path first because it looked like you sorted the paths alphabetically.