### PR TITLE
Add assertion to remove warning in `MiddlewareTest`

### DIFF
--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -3,5 +3,7 @@ require "application_system_test_case"
 class MiddlewareTest < ActionDispatch::IntegrationTest
   test "don't fail on redirects" do
     get "/redirected"
+
+    assert_response :moved_permanently
   end
 end


### PR DESCRIPTION
This pull request adds an assertion to the redirect test in `MiddlewareTest` to remove the missing assertions warning:

```
❯ bin/rails test
Run options: --seed 5678

Test is missing assertions: `test_don't_fail_on_redirects` /Users/marcoroth/Development/spark/test/middleware_test.rb:4 
............

Finished in 23.007887s, 0.5216 runs/s, 1.3474 assertions/s. 12 runs, 31 assertions, 0 failures, 0 errors, 0 skips
```