### PR TITLE
Allow locales changes to reload the page

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,14 +62,14 @@ config.hotwire.spark.html_paths += %w[ lib ]
 
 ### Monitored paths
 
-| Name                  | Description                                                                                                                                       |
-|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| `html_paths`          | Paths where file changes trigger a content refresh. By default: `app/controllers`, `app/helpers`, `app/assets/images`, `app/models`, `app/views`. |
-| `html_extensions`     | The extensions to monitor for HTML content changes. By default: `rb`, `erb`, `png`, `jpg`, `jpeg`, `webp`, `svg`.                                 |
-| `css_paths`           | Paths where file changes trigger a CSS refresh. By default: `app/assets/stylesheets` or `app/assets/builds` if exists.                            |
-| `css_extensions`      | The extensions to monitor for CSS changes. By default: `css`.                                                                                     |
-| `stimulus_paths`      | Paths where file changes trigger a Stimulus controller refresh. By default: `app/javascript/controllers`.                                         |
-| `stimulus_extensions` | The extensions to monitor for Stimulus changes. By default: `js`.                                                                                 |
+| Name                  | Description                                                                                                                                                         |
+|-----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `html_paths`          | Paths where file changes trigger a content refresh. By default: `app/controllers`, `app/helpers`, `app/assets/images`, `app/models`, `app/views`, `config/locales`. |
+| `html_extensions`     | The extensions to monitor for HTML content changes. By default: `rb`, `erb`, `png`, `jpg`, `jpeg`, `webp`, `svg`, `yaml`, `yml`.                                    |
+| `css_paths`           | Paths where file changes trigger a CSS refresh. By default: `app/assets/stylesheets` or `app/assets/builds` if exists.                                              |
+| `css_extensions`      | The extensions to monitor for CSS changes. By default: `css`.                                                                                                       |
+| `stimulus_paths`      | Paths where file changes trigger a Stimulus controller refresh. By default: `app/javascript/controllers`.                                                           |
+| `stimulus_extensions` | The extensions to monitor for Stimulus changes. By default: `js`.                                                                                                   |
 
 ## License
 

--- a/lib/hotwire/spark/default_options.rb
+++ b/lib/hotwire/spark/default_options.rb
@@ -15,8 +15,8 @@ class Hotwire::Spark::DefaultOptions
         enabled: Rails.env.development?,
         css_paths: File.directory?("app/assets/builds") ? %w[ app/assets/builds ] : %w[ app/assets/stylesheets ],
         css_extensions: %w[ css ],
-        html_paths: %w[ app/controllers app/helpers app/assets/images app/models app/views ],
-        html_extensions: %w[ rb erb png jpg jpeg webp svg ],
+        html_paths: %w[ app/controllers app/helpers app/assets/images app/models app/views config/locales ],
+        html_extensions: %w[ rb erb png jpg jpeg webp svg yaml yml ],
         stimulus_paths: %w[ app/javascript/controllers ],
         stimulus_extensions: %w[ js ],
         html_reload_method: :morph

--- a/test/dummy/app/views/home/show.html.erb
+++ b/test/dummy/app/views/home/show.html.erb
@@ -2,5 +2,6 @@
   <p>This is pretty cool, isn't it?</p>
   <p>_REPLACE_HTML_</p>
   <p id="replace">_REPLACE_</p>
+  <p id="translation"><%= I18n.t(".hello") %></p>
   <%= image_tag "green_rectangle.png", id: "image" %>
 </div>

--- a/test/yaml_html_reload_test.rb
+++ b/test/yaml_html_reload_test.rb
@@ -1,0 +1,13 @@
+require "application_system_test_case"
+
+class YamlHtmlReloadTest < ApplicationSystemTestCase
+  test "yaml changes reloads the page" do
+    visit root_path
+
+    assert_equal "Hello world", find("#translation").text
+
+    edit_file "config/locales/en.yml", replace: "Hello world", with: "Hello spark"
+
+    assert_equal "Hello spark", find("#translation").text
+  end
+end


### PR DESCRIPTION
I've noticed that many of the applications I work on use I18n translations and that Spark doesn't reload on these changes. Since a lot of the copy is stored in the locales YAML files, I thought it would be a good idea to add the `config/locales` directory as a default to the HTML paths.

This way, users can make changes to the YAML files more easily and see the changes reflected in the HTML right away. What do you think?