### PR TITLE
Support direct puma process

### DIFF
--- a/lib/hotwire-spark.rb
+++ b/lib/hotwire-spark.rb
@@ -24,7 +24,7 @@ module Hotwire::Spark
     end
 
     def enabled?
-      enabled && defined?(Rails::Server)
+      enabled && (defined?(Rails::Server) || $PROGRAM_NAME =~ /puma/)
     end
 
     def cable_server


### PR DESCRIPTION
Closes https://github.com/hotwired/spark/issues/57

Ensures spark is enabled both when in the context of the Rails server as well as when puma is booted using its own executable.