### PR TITLE
Add nonce for strict Content Security Policy

### DIFF
--- a/lib/hotwire/spark/middleware.rb
+++ b/lib/hotwire/spark/middleware.rb
@@ -40,7 +40,7 @@ class Hotwire::Spark::Middleware
 
     def script_tag
       script_path = view_helpers.path_to_asset("hotwire_spark.js")
-      view_helpers.javascript_include_tag(script_path, defer: "")
+      view_helpers.javascript_include_tag(script_path, defer: "", nonce: true)
     end
 
     def view_helpers


### PR DESCRIPTION
Without a nonce an application with the following config will have errors in the browser.

```
Rails.application.configure do
  config.content_security_policy do |policy|
    policy.script_src :strict_dynamic
  end
end
```

Error (translated):
```
The page settings have blocked the execution of a script (script-src-elem) at http://localhost:3000/assets/hotwire_spark-d7e0ee73.js because it violates the following directive: ‘script-src 'strict-dynamic' 'nonce-e46d3874a949188ba1c4f5bbb3f93f8c'’
```